### PR TITLE
Adjust for incorrect GetTickCount return type

### DIFF
--- a/clockify_idleless/idleless.py
+++ b/clockify_idleless/idleless.py
@@ -126,7 +126,13 @@ def get_idle_duration():
     last_input_info = LASTINPUTINFO()
     last_input_info.cbSize = sizeof(last_input_info)
     windll.user32.GetLastInputInfo(byref(last_input_info))
-    millis = windll.kernel32.GetTickCount() - last_input_info.dwTime
+    tick_count = windll.kernel32.GetTickCount()
+    
+    # GetTickCount returns an unsigned integer but the value is actually an unsigned int
+    # So we have to adjust for it 
+    tick_count += 2 ** 32 if tick_count < 0 else 0
+    
+    millis = tick_count - last_input_info.dwTime
     return millis / 1000.0
 
 


### PR DESCRIPTION
GetTickCount returns an unsigned int value but is typed as a signed int. For low values this has no effect. If you leave your machine running for a long time your tick count can run up high enough to overflow the signed int limit and flip into negative values while GetLastInputInfo correctly keeps increasing.

We can add 2**32 if GetTickCount returns negative to correct for this.